### PR TITLE
Added padding to menu items to centre align them

### DIFF
--- a/CLImageEditor/ViewController/_CLImageEditorViewController.m
+++ b/CLImageEditor/ViewController/_CLImageEditorViewController.m
@@ -415,14 +415,26 @@
     CGFloat W = 70;
     CGFloat H = _menuView.height;
     
+    int toolCount = 0;
+    float padding = 0;
+    for(CLImageToolInfo *info in self.toolInfo.sortedSubtools){
+        if(info.available){
+            toolCount++;
+        }
+    }
+    
+    if (toolCount == 4 || toolCount == 5) {
+        padding = ([UIScreen mainScreen].bounds.size.width-(W*toolCount))/(toolCount+1);
+    }
+    
     for(CLImageToolInfo *info in self.toolInfo.sortedSubtools){
         if(!info.available){
             continue;
         }
         
-        CLToolbarMenuItem *view = [CLImageEditorTheme menuItemWithFrame:CGRectMake(x, 0, W, H) target:self action:@selector(tappedMenuView:) toolInfo:info];
+        CLToolbarMenuItem *view = [CLImageEditorTheme menuItemWithFrame:CGRectMake(x+padding, 0, W, H) target:self action:@selector(tappedMenuView:) toolInfo:info];
         [_menuView addSubview:view];
-        x += W;
+        x += W+padding;
     }
     _menuView.contentSize = CGSizeMake(MAX(x, _menuView.frame.size.width+1), 0);
 }

--- a/CLImageEditor/ViewController/_CLImageEditorViewController.m
+++ b/CLImageEditor/ViewController/_CLImageEditorViewController.m
@@ -416,15 +416,16 @@
     CGFloat H = _menuView.height;
     
     int toolCount = 0;
-    float padding = 0;
+    CGFloat padding = 0;
     for(CLImageToolInfo *info in self.toolInfo.sortedSubtools){
         if(info.available){
             toolCount++;
         }
     }
     
-    if (toolCount == 4 || toolCount == 5) {
-        padding = ([UIScreen mainScreen].bounds.size.width-(W*toolCount))/(toolCount+1);
+    CGFloat diff = _menuView.frame.size.width - toolCount * W;
+    if (0<diff && diff<2*W) {
+        padding = diff/(toolCount+1);
     }
     
     for(CLImageToolInfo *info in self.toolInfo.sortedSubtools){


### PR DESCRIPTION
The alignment of menu items has been bugging me for a while so Ive put together a pull request.

This change centre aligns the menu items by adding some padding to each frame's x coordinate, but only if there are 4 or 5 visible. If there <4 then they'll be left aligned as previous.

It takes into account the width of the screen so looks good on all iPhone screen widths