### PR TITLE
Bug fix: Issue #161: Main Tool Can Now be Disabled From Appearing

### DIFF
--- a/CLImageEditor/ViewController/_CLImageEditorViewController.m
+++ b/CLImageEditor/ViewController/_CLImageEditorViewController.m
@@ -206,8 +206,6 @@
     [self initMenuScrollView];
     [self initImageScrollView];
     
-    [self setMenuView];
-    
     if(_imageView==nil){
         _imageView = [UIImageView new];
         [_scrollView addSubview:_imageView];
@@ -224,6 +222,7 @@
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
+    [self setMenuView];
     if(self.targetImageView){
         [self expropriateImageView];
     }


### PR DESCRIPTION
This patch is created to fix Issue #161. The bug happens when any
main tool is disabled using the method described in README.md, it
doesn't remove it from appearing in the editor menu view.

The problem occurs due to the menu is set when the class is
initialized before allowing user to customize the tools. When the
editor is presented, it doesn't roll in the latest main tool
settings done by the user. Hence, all 'disabled' main tool
re-appeared. The responsible code lies in:

_CLImageEditorViewController.m:
ViewDidLoad: Line 209:		[self setMenuView];

The fix is to postpone the appearance to ViewDidAppear: instead.
ViewDidAppear: is called when the mainViewController (e.g: self)
is presenting the editorViewController. Hence, it will accepts
user's customization settings and remove the disabled main tool
from the menu view.

Signed-off-by: (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>