### PR TITLE
Fix typo

### DIFF
--- a/CLImageEditor/ImageTools/CLBlurTool/CLBlurTool.m
+++ b/CLImageEditor/ImageTools/CLBlurTool/CLBlurTool.m
@@ -7,7 +7,7 @@
 
 #import "CLBlurTool.h"
 
-static NSString* const kCLBlurToolNormalIconName = @"nonrmalIconAssetsName";
+static NSString* const kCLBlurToolNormalIconName = @"normalIconAssetsName";
 static NSString* const kCLBlurToolCircleIconName = @"circleIconAssetsName";
 static NSString* const kCLBlurToolBandIconName = @"bandIconAssetsName";
 


### PR DESCRIPTION
Fix typo in kCLBlurToolNormalIconName. “nonrmalIconAssetsName” to “normalIconAssetsName”