### PR TITLE
fix: delete the last character will cause app crash

### DIFF
--- a/OptionalImageTools/CLTextTool/CLTextSettingView.m
+++ b/OptionalImageTools/CLTextTool/CLTextSettingView.m
@@ -301,7 +301,7 @@
 - (void)textViewDidChange:(UITextView*)textView
 {
     NSRange selection = textView.selectedRange;
-    if(selection.location+selection.length == textView.text.length && [textView.text characterAtIndex:textView.text.length-1] == '\n') {
+    if(selection.location+selection.length == textView.text.length && textView.text.length >= 1 && [textView.text characterAtIndex:textView.text.length-1] == '\n') {
         [textView layoutSubviews];
         [textView scrollRectToVisible:CGRectMake(0, textView.contentSize.height - 1, 1, 1) animated:YES];
     }


### PR DESCRIPTION
When users delete the last character of string, the app will crash so add a condition to prevent it.
There is an opened issue related it https://github.com/yackle/CLImageEditor/issues/236